### PR TITLE
Ensure height is a integer

### DIFF
--- a/src/bynder-selector.js
+++ b/src/bynder-selector.js
@@ -15,7 +15,7 @@ function updateDisabled(disabled) {
 }
 
 function updateSize() {
-  const height = Math.max($("html").height(), document.body.offsetHeight, 100);
+  const height = Math.ceil(Math.max($("html").height(), document.body.offsetHeight, 100));
   CustomElement.setHeight(height + 30);
 }
 


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`issue number`
No current issue is reported in the issue tracker but we experiencing an js error in CustomeElement.SetHeight in the situation that the height is a decimal value (for example: 348.9). By ceiling the height we avoid this issue.

js error:
```
Uncaught Error: The specified height must be a positive integer.
    at d.setHeight (CustomElement.ts:155)
    at Object.p [as setHeight] (index.ts:17)
    at updateSize (bynder-selector.js:19)
    at renderSelected (bynder-selector.js:38)
    at setupSelector (bynder-selector.js:82)
    at bynder-selector.js:127
    at CustomElement.ts:79
    at r._executeCallbacks (CustomExtensionMessageSender.ts:105)
    at CustomExtensionMessageSender.ts:115
```